### PR TITLE
add TYPST_FONT_PATHS, TYPST_PACKAGE_PATH and TYPST_PACKAGE_CACHE_PATH

### DIFF
--- a/template/flake.nix
+++ b/template/flake.nix
@@ -77,13 +77,17 @@
         verbose = false;
       };
 
-      devShells.${system}.default = pkgs.mkShell {
-        stdenv = pkgs.stdenvNoCC;
+      devShells.${system}.default = pkgs.mkShellNoCC {
         inputsFrom = [ self.packages.${system}.default ];
         packages = [
           pkgs.tinymist
           pkgs.typstyle
         ];
+        inherit (self.packages.${system}.default)
+          TYPST_FONT_PATHS
+          TYPST_PACKAGE_PATH
+          TYPST_PACKAGE_CACHE_PATH
+          ;
       };
     };
 }

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -83,11 +83,6 @@
           pkgs.tinymist
           pkgs.typstyle
         ];
-        inherit (self.packages.${system}.default)
-          TYPST_FONT_PATHS
-          TYPST_PACKAGE_PATH
-          TYPST_PACKAGE_CACHE_PATH
-          ;
       };
     };
 }


### PR DESCRIPTION
 to passthru for reuse in devShells, so that tinymist can use them.