### PR TITLE
Add quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ A library for building Typst documents with Nix. Goals:
 5. Supports key-values inputs (Typst's `sys.inputs` dictionary)
 6. Nixpkg's fonts
 
+## Quickstart
+
+```bash
+mkdir my-typst-document
+cd my-typst-document
+nix flake init --template github:RossSmyth/press
+nix build
+```
+
 ## Status
 
 Basically done. In "maintenence mode". Let me know if you find any issues or have feature requests.


### PR DESCRIPTION
Just a suggestion.

EDIT: Sidenote, this repo should eventually be merged into Nixpkgs IMO. It's clean enough for it, and it's really confusing that Nix only has partial Typst support in the form of packages. And thanks for the project, it's really great.

EDIT2: Maybe also a few points on why to use this rather than Typix? It was the first question when I shared this repo to reddit. My response:

```md
It supports the Typst packages from Nixpkgs, which Typix does not do, and
the API is a whole lot simpler. I wanted to get into Typst but having the
use-case of a simple document with a couple of standard Typst documents,
it seemed unacceptable. Press let's you build a document using just:

document = pkgs.buildTypstDocument {
  name = "myDoc";
  src = ./.;
  # Adds note-me from Nixpkgs
  typstEnv = p: [ p.note-me ];
};

Which is a whole lot simpler than what the [Typst
API](https://github.com/loqusion/typix/blob/main/examples/typst-packages/flake.nix)
offers. To be clear, Press is not my project, but I'm really glad I found
it and surprised so few use it compared to Typix.
```

I'm not going to include it in here, since I think it's better if you do it.