### PR TITLE
fix: Set project root to enable absolute path relative to src

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -172,7 +172,7 @@ in
             runHook preBuild
 
             echo "Calling Typst with 'typst ''${typstArgs[@]}'"
-            typst "''${typstArgs[@]}" $out
+            typst "''${typstArgs[@]}" --root $PWD $out
 
             runHook postBuild
           '';

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -32,11 +32,11 @@ let
       {
         name,
         file ? finalAttrs.name + ".typ",
+        src ? ./documents,
         ...
-      }@args:
+      }:
       {
-        inherit file;
-        src = ./documents;
+        inherit file src;
       };
   };
 in
@@ -184,5 +184,11 @@ in
   timestamp = mkTest {
     name = "timestamp";
     creationTimestamp = 1;
+  };
+
+  project-root = mkTest {
+    name = "project-root";
+    src = ./documents/project-root;
+    file = "mydoc/main.typ";
   };
 }

--- a/tests/documents/project-root/lib/mylib.typ
+++ b/tests/documents/project-root/lib/mylib.typ
@@ -1,0 +1,1 @@
+#let importme = "This is imported from mylib!"

--- a/tests/documents/project-root/mydoc/main.typ
+++ b/tests/documents/project-root/mydoc/main.typ
@@ -1,0 +1,5 @@
+// NOTE: Ignore the `file not found` error from the LSP.
+// This should works in a nix derivation.
+#import "/lib/mylib.typ"
+
+#mylib.importme // => "This is imported from mylib!"


### PR DESCRIPTION
## Use Case Example

### File Structure

```
.
├── lib
│   └── mylib.typ
├── src
│   └── mydoc
│       └── main.typ
├── flake.nix
...
```

### `lib/mylib.typ`

```typ
#let foo = "bar"
```

### `src/mydoc/main.typ`

```typ
#import "/lib/mylib.typ"
```

### `flake.nix`

```nix
pkgs.buildTypstDocument {
  name = "mydoc";
  src = ./.;
  file = "src/mydoc/main.typ";
};
```