### PR TITLE
fix: update shellHook to append paths for TYPST_FONT_PATHS

### DIFF
--- a/src/wrap-typst.nix
+++ b/src/wrap-typst.nix
@@ -48,7 +48,7 @@ lib.extendMkDerivation {
       shellHook = ''
         export TYPST_PACKAGE_CACHE_PATH="${typst}/lib/typst/packages"
         export TYPST_PACKAGE_PATH="${userPackages}/share/typst/packages"
-        export TYPST_FONT_PATHS="${fonts}/share/fonts"
+        export TYPST_FONT_PATHS="''${TYPST_FONT_PATHS:+$TYPST_FONT_PATHS:}${fonts}/share/fonts"
         export SOURCE_DATE_EPOCH=${
           if creationTimestamp != null then builtins.toString creationTimestamp else "315532800"
         }


### PR DESCRIPTION
useful for environments where working with tinymist with multiple typst files with different fonts defined. imo it makes more sense if all of the defined fonts are available to tinymist rather than just the last defined `shellHook` from `inputsFrom`.

edit: learned that typst only supports multiple paths for fonts, and does not have similar functionality for packages.