### PR TITLE
fix(buildTypstDocument): resolve the full typstEnv dependency closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ document = pkgs.buildTypstDocument {
 };
 ```
 
+Only list the packages your document imports directly; their dependencies are
+resolved and added to the environment for you.
+
 
 If you want to use a non-Universe package:
 

--- a/src/buildTypstDocument.nix
+++ b/src/buildTypstDocument.nix
@@ -9,6 +9,27 @@
 }:
 let
   inherit (lib.asserts) assertMsg;
+
+  # `typst.withPackages` only links each requested package's *direct*
+  # `typstDeps` into the environment. Anything deeper in the graph
+  # (e.g. fletcher -> cetz -> oxifmt) is left out, so Typst falls back to
+  # fetching it over the network at build time, which fails in the sandbox
+  # with "failed to download package (OpenSSL error)".
+  #
+  # So resolve the whole dependency closure here instead.
+  closureItem = pkg: {
+    key = pkg.outPath;
+    value = pkg;
+  };
+
+  typstClosure =
+    packages:
+    lib.map (item: item.value) (
+      builtins.genericClosure {
+        startSet = lib.map closureItem packages;
+        operator = item: lib.map closureItem (item.value.typstDeps or [ ]);
+      }
+    );
 in
 lib.extendMkDerivation {
   # No need for CC here
@@ -110,7 +131,7 @@ lib.extendMkDerivation {
         # Typst does not have target, so we just use the build platform's Typst so
         # it never tries to do anything weird like fail to build a PDF when targeting
         # something.
-        typst = typst.withPackages typstEnv;
+        typst = typst.withPackages (typstPkgs: typstClosure (typstEnv typstPkgs));
       };
 
       # Put the inputs in the right format

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -66,6 +66,12 @@ in
     typstEnv = p: [ p.note-me_0_5_0 ];
   };
 
+  transitiveImports = mkTest {
+    name = "transitiveImport";
+    # fletcher -> cetz -> oxifmt, so only the closure of this makes it build
+    typstEnv = p: [ p.fletcher_0_5_8 ];
+  };
+
   fonts = mkTest {
     name = "fonts";
     fonts = [

--- a/tests/documents/transitiveImport.typ
+++ b/tests/documents/transitiveImport.typ
@@ -1,0 +1,10 @@
+// fletcher depends on cetz, which in turn depends on oxifmt.
+// Importing it exercises the whole dependency closure, not just the
+// packages named in `typstEnv`.
+#import "@preview/fletcher:0.5.8": diagram, edge, node
+
+#diagram(
+  node((0, 0), [Success!]),
+  edge("-|>"),
+  node((1, 0), [Success!]),
+)


### PR DESCRIPTION
`typst.withPackages` builds its environment from each requested package plus that package's direct `propagatedBuildInputs`, and `buildEnv` does not follow propagated inputs any further. Dependencies more than one level deep are therefore missing from the environment, and Typst falls back to fetching them from the network mid-build:

    error: failed to download package (OpenSSL error)
      ┌─ @preview/cetz:0.3.4/src/deps.typ:1:8
      │
    1 │ #import "@preview/oxifmt:0.2.1"

`typstEnv = p: [ p.fletcher ]` pulls in cetz, but not the oxifmt that cetz itself imports. Work around it by expanding `typstEnv` to its full closure over `passthru.typstDeps` before handing it to `withPackages`.

Adds a test document importing fletcher 0.5.8 (-> cetz -> oxifmt), which fails to build without this change.